### PR TITLE
[EPIC] Parse args, correct frames order

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "PHP errors Catcher module for Hawk.so",
     "keywords": ["hawk", "php", "error", "catcher", "monolog"],
     "type": "library",
-    "version": "2.0.1",
+    "version": "2.1.0",
     "license": "MIT",
     "require": {
         "ext-curl": "*",

--- a/example.php
+++ b/example.php
@@ -12,8 +12,8 @@
 require_once './vendor/autoload.php';
 
 \Hawk\Catcher::init([
-    'integrationToken' => 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwcm9qZWN0SWQiOiI2MGJhODIyNzM1M2MyNzAwMjMxMWE1MzEiLCJpYXQiOjE2MjI4MzU3NTF9.uoKJEwd62N7SfWCTQfSrFuor8xgKCq2WPCPeMDPBHVU',
-    'url'              => 'http://localhost:3000/'
+    'integrationToken' => 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwcm9qZWN0SWQiOiI2MGJmNzFjMmZmODQ5MWFmNWIwZWZiYWUiLCJpYXQiOjE2MjMxNTkyMzR9.dwFU0VTdKsnDDMTKmGUXkxCs0sH6jsj55uPpqCbXBHA',
+//    'url'              => 'http://localhost:3000/'
 ]);
 
 function randStr()

--- a/example.php
+++ b/example.php
@@ -12,20 +12,32 @@
 require_once './vendor/autoload.php';
 
 \Hawk\Catcher::init([
-    'integrationToken' => 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwcm9qZWN0SWQiOiI2MDY2ZWI5N2U3NTU2ZDAwMjM2M2UyNjYiLCJpYXQiOjE2MTczNTc3MTl9.OpelHPPvS_TB8wUqCHRzcO3-Cp1VNL0UzlFuMfR35tk',
-    'release'          => '12345',
-    'url'              => 'http://localhost:3000/',
-    'beforeSend'       => function (\Hawk\EventPayload $eventPayload) {
-        $user = $eventPayload->getUser();
-
-        if (!empty($user['email'])) {
-            unset($user['email']);
-
-            $eventPayload->setUser($user);
-        }
-
-        return $eventPayload;
-    }
+    'integrationToken' => 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwcm9qZWN0SWQiOiI2MGJhODIyNzM1M2MyNzAwMjMxMWE1MzEiLCJpYXQiOjE2MjI4MzU3NTF9.uoKJEwd62N7SfWCTQfSrFuor8xgKCq2WPCPeMDPBHVU',
+    'url'              => 'http://localhost:3000/'
 ]);
 
-$a = 1 / 0;
+function randStr() {
+    return bin2hex(openssl_random_pseudo_bytes(8));
+}
+
+
+function test($aTest) {
+    return divZero($aTest);
+}
+
+function divZero($aDiv) {
+    $b = 0;
+
+    $randA =  randStr();
+
+    fail($randA);
+
+    return $aDiv / $b;
+}
+
+function fail($numFail){
+    throw new Exception('Error ' . $numFail . ' at ' . date('j F Y h:i:s'));
+}
+
+
+test(15);

--- a/example.php
+++ b/example.php
@@ -16,16 +16,19 @@ require_once './vendor/autoload.php';
     'url'              => 'http://localhost:3000/'
 ]);
 
-function randStr() {
+function randStr()
+{
     return bin2hex(openssl_random_pseudo_bytes(8));
 }
 
 
-function test($aTest) {
+function test($aTest)
+{
     return divZero($aTest);
 }
 
-function divZero($aDiv) {
+function divZero($aDiv)
+{
     $b = 0;
 
     $randA =  randStr();
@@ -35,7 +38,8 @@ function divZero($aDiv) {
     return $aDiv / $b;
 }
 
-function fail($numFail){
+function fail($numFail)
+{
     throw new Exception('Error ' . $numFail . ' at ' . date('j F Y h:i:s'));
 }
 

--- a/example.php
+++ b/example.php
@@ -21,11 +21,24 @@ function randStr()
     return bin2hex(openssl_random_pseudo_bytes(8));
 }
 
-
-function test($aTest)
+class Test
 {
-    return divZero($aTest);
+    public function __construct()
+    {
+    }
+
+    public function test($aTest)
+    {
+        return self::testStatic($aTest);
+    }
+
+    public static function testStatic($aTest)
+    {
+        return divZero($aTest);
+    }
 }
+
+$t = new Test();
 
 function divZero($aDiv)
 {
@@ -44,4 +57,4 @@ function fail($numFail)
 }
 
 
-test(15);
+$t->test(5);

--- a/src/Util/Stacktrace.php
+++ b/src/Util/Stacktrace.php
@@ -138,8 +138,15 @@ final class Stacktrace
     private static function getArgs($backtraceFrame) {
         $backtraceFrameArgs = $backtraceFrame['args'];
 
+        /**
+         * According to docs: the ReflectionFunction/ReflectionMethod class
+         * reports information about a function/method.
+         */
         $reflectionFunction = null;
 
+        /**
+         * Trying to create a correct ReflectionMethod
+         */
         try {
             if (isset($backtraceFrame['class'], $backtraceFrame['function'])) {
                 if (method_exists($backtraceFrame['class'], $backtraceFrame['function'])) {
@@ -156,8 +163,15 @@ final class Stacktrace
             // Reflection failed, we do nothing instead
         }
 
+        /**
+         * Defining an array of arguments
+         */
         $argumentValues = [];
 
+        /**
+         * If reflectionFunction exists then trying to fill arguments array
+         * otherwise saving params as arg0, arg1, ...
+         */
         if (null !== $reflectionFunction) {
             foreach ($reflectionFunction->getParameters() as $reflectionParameter) {
                 $parameterPosition = $reflectionParameter->getPosition();
@@ -170,15 +184,14 @@ final class Stacktrace
             }
         } else {
             foreach ($backtraceFrame['args'] as $parameterPosition => $parameterValue) {
-                $argumentValues['param' . $parameterPosition] = $parameterValue;
+                $argumentValues['arg' . $parameterPosition] = $parameterValue;
             }
         }
 
         /**
-         * Uncomment and remove the following code when hawk.types
-         * supports non-iterable list of arguments
+         * @todo Remove the following code when hawk.types
+         *       supports non-iterable list of arguments
          */
-        //$stack[$index]['arguments'] = $argumentValues;
         $newArgumentsValues = [];
         foreach ($argumentValues as $name => $value) {
             $newArgumentsValues[] = $name . ' = ' . $value;

--- a/src/Util/Stacktrace.php
+++ b/src/Util/Stacktrace.php
@@ -243,7 +243,7 @@ final class Stacktrace
      *
      * @return \ReflectionFunction|\ReflectionMethod|null
      */
-    private static function getReflectionMethod($frame)
+    private static function getReflectionMethod(array $frame): ?ReflectionFunctionAbstract
     {
         /**
          * Trying to create a correct reflection

--- a/src/Util/Stacktrace.php
+++ b/src/Util/Stacktrace.php
@@ -147,7 +147,7 @@ final class Stacktrace
      *
      * @return string
      */
-    private static function composeFunctionName($frame): string
+    private static function composeFunctionName(array $frame): string
     {
         /**
          * Set an empty function name to be returned

--- a/src/Util/Stacktrace.php
+++ b/src/Util/Stacktrace.php
@@ -88,6 +88,7 @@ final class Stacktrace
                  * Remove this call
                  */
                 unset($stack[$index]);
+
                 continue;
             }
 
@@ -106,6 +107,7 @@ final class Stacktrace
                  * We will add it here manually later
                  */
                 unset($stack[$index]);
+
                 continue;
             }
 
@@ -135,7 +137,8 @@ final class Stacktrace
      *
      * @return array
      */
-    private static function getArgs($backtraceFrame) {
+    private static function getArgs($backtraceFrame)
+    {
         $backtraceFrameArgs = $backtraceFrame['args'];
 
         /**

--- a/src/Util/Stacktrace.php
+++ b/src/Util/Stacktrace.php
@@ -35,8 +35,6 @@ final class Stacktrace
          */
         $stack = $exception->getTrace();
 
-        var_dump($stack);
-
         /**
          * Prepare new stack to be filled
          */

--- a/src/Util/Stacktrace.php
+++ b/src/Util/Stacktrace.php
@@ -176,7 +176,7 @@ final class Stacktrace
      *
      * @return array
      */
-    private static function getArgs($frame): array
+    private static function getArgs(array $frame): array
     {
         /**
          * Defining an array of arguments to be returned


### PR DESCRIPTION
**was** and **now**

![image](https://user-images.githubusercontent.com/15259299/120855076-adf90600-c586-11eb-83cc-95e5c657efd7.png)
