### PR TITLE
Hotfix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "PHP errors Catcher module for Hawk.so",
     "keywords": ["hawk", "php", "error", "catcher", "monolog"],
     "type": "library",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "license": "MIT",
     "require": {
         "ext-curl": "*",

--- a/src/Util/Stacktrace.php
+++ b/src/Util/Stacktrace.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hawk\Util;
 
+use ReflectionFunctionAbstract;
 use Throwable;
 
 /**


### PR DESCRIPTION
Critical: missed namespace for `ReflectionFunctionAbstract` class