### PR TITLE
Fix error on stringify value function

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "PHP errors Catcher module for Hawk.so",
     "keywords": ["hawk", "php", "error", "catcher", "monolog"],
     "type": "library",
-    "version": "2.1.2",
+    "version": "2.1.3",
     "license": "MIT",
     "require": {
         "ext-curl": "*",

--- a/src/Util/Stacktrace.php
+++ b/src/Util/Stacktrace.php
@@ -357,9 +357,11 @@ final class Stacktrace
         if (is_object($value)) {
             $value = get_class($value);
         } elseif (is_iterable($value)) {
-            $value = implode(',', iterator_to_array($value));
-        } elseif (is_array($value)) {
-            $value = implode(',', $value);
+            if (is_array($value)) {
+                $value = implode(',', $value);
+            } else {
+                $value = implode(',', iterator_to_array($value));
+            }
         } elseif (is_bool($value)) {
             $value = $value === true ? 'true' : 'false';
         } elseif (is_null($value)) {


### PR DESCRIPTION
`is_iterable` returns `true` on array and `Traversable` objects, but `iterator_to_array` accepts only `Traversable`