### PR TITLE
Fix: Add null check for previous error handler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "PHP errors Catcher module for Hawk.so",
     "keywords": ["hawk", "php", "error", "catcher"],
     "type": "library",
-    "version": "2.2.2",
+    "version": "2.2.3",
     "license": "MIT",
     "require": {
         "ext-curl": "*",

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -203,7 +203,9 @@ class Handler
         if ($event !== null) {
             $this->send($event);
 
-            return false !== ($this->previousErrorHandler)($level, $message, $file, $line);
+            if (null !== $this->previousErrorHandler) {
+                return false !== ($this->previousErrorHandler)($level, $message, $file, $line);
+            }
         }
 
         return false;


### PR DESCRIPTION
The update ensures that the previous error handler is only called if it is properly initialized as a callable. If the handler is `null`, the script now safely bypasses the call.