### PR TITLE
Fix empty title issue by using exception class name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "PHP errors Catcher module for Hawk.so",
     "keywords": ["hawk", "php", "error", "catcher"],
     "type": "library",
-    "version": "2.2.3",
+    "version": "2.2.4",
     "license": "MIT",
     "require": {
         "ext-curl": "*",

--- a/src/EventPayloadBuilder.php
+++ b/src/EventPayloadBuilder.php
@@ -71,7 +71,7 @@ class EventPayloadBuilder
             $exception = $data['exception'];
             $stacktrace = $this->stacktraceFrameBuilder->buildStack($exception);
 
-            $eventPayload->setTitle($exception->getMessage());
+            $eventPayload->setTitle($exception->getMessage() ?: get_class($exception));
         } else {
             $stacktrace = debug_backtrace();
         }


### PR DESCRIPTION
Now, instead of sending an empty title, the name of the exception class is sent as the title when the message is not provided. This helps to ensure that the event payload contains meaningful information for better debugging and error tracking.