### PR TITLE
[+] CurlTransport timeout

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "PHP errors Catcher module for Hawk.so",
     "keywords": ["hawk", "php", "error", "catcher"],
     "type": "library",
-    "version": "2.2.5",
+    "version": "2.2.6",
     "license": "MIT",
     "require": {
         "ext-curl": "*",

--- a/src/Catcher.php
+++ b/src/Catcher.php
@@ -157,7 +157,7 @@ final class Catcher
         $builder->registerAddon(new Headers());
         $builder->registerAddon(new Environment());
 
-        $transport = new CurlTransport($options->getUrl());
+        $transport = new CurlTransport($options->getUrl(), $options->getTimeout());
 
         $this->handler = new Handler($options, $transport, $builder);
 

--- a/src/Options.php
+++ b/src/Options.php
@@ -21,7 +21,8 @@ class Options
         'url'              => 'https://k1.hawk.so/',
         'release'          => '',
         'error_types'      => \E_ALL,
-        'beforeSend'       => null
+        'beforeSend'       => null,
+        'timeout'          => 10,
     ];
 
     /**
@@ -52,6 +53,11 @@ class Options
     public function getUrl(): string
     {
         return $this->options['url'];
+    }
+
+    public function getTimeout(): int
+    {
+        return $this->options['timeout'];
     }
 
     /**

--- a/src/Transport/CurlTransport.php
+++ b/src/Transport/CurlTransport.php
@@ -60,7 +60,7 @@ class CurlTransport implements TransportInterface
 
         $curl = curl_init();
         curl_setopt($curl, CURLOPT_URL, $this->url);
-        curl_setopt($curl, CURLOPT_POST, 1);
+        curl_setopt($curl, CURLOPT_POST, true);
         curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($event, JSON_UNESCAPED_UNICODE));
         curl_setopt($curl, CURLOPT_HTTPHEADER, ['Content-Type: application/json']);
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);

--- a/src/Transport/CurlTransport.php
+++ b/src/Transport/CurlTransport.php
@@ -21,13 +21,21 @@ class CurlTransport implements TransportInterface
     private $url;
 
     /**
+     * CURLOPT_TIMEOUT
+     *
+     * @var int
+     */
+    private $timeout;
+
+    /**
      * CurlTransport constructor.
      *
      * @param string $url
      */
-    public function __construct(string $url)
+    public function __construct(string $url, int $timeout)
     {
         $this->url = $url;
+        $this->timeout = $timeout;
     }
 
     /**
@@ -56,7 +64,7 @@ class CurlTransport implements TransportInterface
         curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($event, JSON_UNESCAPED_UNICODE));
         curl_setopt($curl, CURLOPT_HTTPHEADER, ['Content-Type: application/json']);
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($curl, CURLOPT_TIMEOUT, 10);
+        curl_setopt($curl, CURLOPT_TIMEOUT, $this->timeout);
         $response = curl_exec($curl);
         curl_close($curl);
 


### PR DESCRIPTION
This PR adds a `\Hawk\Options::$timeout` param to the Hawk SDK, which set cURL timeout for `\Hawk\Transport\CurlTransport`. 

Default value is 10. 

Set custom value via `\Hawk\Catcher::init(['timeout' => 2]);`