### PR TITLE
Change default timeout (10 -> 2 sec)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "PHP errors Catcher module for Hawk.so",
     "keywords": ["hawk", "php", "error", "catcher"],
     "type": "library",
-    "version": "2.2.7",
+    "version": "2.2.8",
     "license": "MIT",
     "require": {
         "ext-curl": "*",

--- a/src/Options.php
+++ b/src/Options.php
@@ -42,7 +42,7 @@ class Options
     /**
      * @var int
      */
-    private $timeout = 10;
+    private $timeout = 2;
 
     /**
      * Map of accepted option keys to class properties.


### PR DESCRIPTION
This update modifies the default timeout value for sending error notifications in the `Options` class