### PR TITLE
Fix JSON encoding to keep Unicode characters unescaped

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "PHP errors Catcher module for Hawk.so",
     "keywords": ["hawk", "php", "error", "catcher"],
     "type": "library",
-    "version": "2.2.9",
+    "version": "2.2.10",
     "license": "MIT",
     "require": {
         "ext-curl": "*",

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -20,7 +20,7 @@ final class Serializer
      */
     public function serializeValue($value): string
     {
-        $encoded = json_encode($this->prepare($value));
+        $encoded = json_encode($this->prepare($value), JSON_UNESCAPED_UNICODE);
 
         if ($encoded === false) {
             return '';


### PR DESCRIPTION
Ensure that JSON payloads retain readable Unicode characters instead of escaped sequences.