### PR TITLE
fix(catchers): validate beforeSend return value to avoid sending invalid payload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "PHP errors Catcher module for Hawk.so",
     "keywords": ["hawk", "php", "error", "catcher"],
     "type": "library",
-    "version": "2.2.10",
+    "version": "2.2.11",
     "license": "MIT",
     "require": {
         "ext-curl": "*",

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -323,9 +323,14 @@ class Handler
         $beforeSendCallback = $this->options->getBeforeSend();
 
         if ($beforeSendCallback) {
-            $eventPayload = $beforeSendCallback($eventPayload);
-            if ($eventPayload === null) {
+            $beforeSendResult = $beforeSendCallback($eventPayload);
+            if ($beforeSendResult === null) {
                 return null;
+            }
+            if ($beforeSendResult instanceof EventPayload) {
+                $eventPayload = $beforeSendResult;
+            } else {
+                error_log('[Hawk] beforeSend must return EventPayload or null. Received: ' . gettype($beforeSendResult));
             }
         }
 


### PR DESCRIPTION
## Problem

When `beforeSend` returns a non-object (e.g. `true`, `undefined`, or omits `return`), that value was used as `payload` and sent to the collector. The backend then stored it as-is (e.g. `payload: true` in MongoDB), which led to:
- GraphQL: `Cannot return null for non-nullable field EventPayload.title`
- Frontend: `TypeError: can't access property "event", l is null` on project overview

Common mistakes:
- `beforeSend: (e) => true` (meant “allow”, but overwrites payload)
- `beforeSend: (e) => { console.log(e); }` (no return → `undefined` as payload)

## Solution

Validate the return value of `beforeSend` and only use it when it’s a valid event object: