### PR TITLE
fix: cap payload depth and improve serialized arg readability for Hawk

### DIFF
--- a/src/EventPayloadBuilder.php
+++ b/src/EventPayloadBuilder.php
@@ -233,8 +233,9 @@ class EventPayloadBuilder
 
     /**
      * Build Hawk `arguments`: string list like "name = serializedValue" (from raw `args` via Serializer).
-     * Limits the number of lines ({@see StacktraceFrameBuilder::MAX_FRAME_ARGUMENTS}) and each line's byte length
-     * ({@see StacktraceFrameBuilder::MAX_ARGUMENT_LINE_BYTES}) for payload size.
+     * Limits the number of lines ({@see StacktraceFrameBuilder::MAX_FRAME_ARGUMENTS}). Serialized values are not
+     * length-truncated; only param names are capped ({@see StacktraceFrameBuilder::formatTruncatedArgumentLine});
+     * prebuilt strings are split on the first `" = "` with {@see StacktraceFrameBuilder::truncatePrebuiltArgumentLine}.
      *
      * @param array $frame
      *
@@ -243,12 +244,11 @@ class EventPayloadBuilder
     private function buildArgumentsList(array $frame): array
     {
         $max = StacktraceFrameBuilder::MAX_FRAME_ARGUMENTS;
-        $maxBytes = StacktraceFrameBuilder::MAX_ARGUMENT_LINE_BYTES;
 
         if (isset($frame['arguments']) && is_array($frame['arguments'])) {
             $out = [];
             foreach (array_slice($frame['arguments'], 0, $max) as $line) {
-                $out[] = $this->truncateArgumentLineString((string) $line, $maxBytes);
+                $out[] = StacktraceFrameBuilder::truncatePrebuiltArgumentLine((string) $line);
             }
 
             return $out;
@@ -257,22 +257,13 @@ class EventPayloadBuilder
         if (!empty($frame['args']) && is_array($frame['args'])) {
             $out = [];
             foreach (array_slice($this->stacktraceFrameBuilder->getFormattedArguments($frame), 0, $max) as $line) {
-                $out[] = $this->truncateArgumentLineString((string) $line, $maxBytes);
+                $out[] = (string) $line;
             }
 
             return $out;
         }
 
         return [];
-    }
-
-    private function truncateArgumentLineString(string $line, int $maxBytes): string
-    {
-        if (strlen($line) <= $maxBytes) {
-            return $line;
-        }
-
-        return substr($line, 0, $maxBytes - 3) . '...';
     }
 
     /**

--- a/src/EventPayloadBuilder.php
+++ b/src/EventPayloadBuilder.php
@@ -233,7 +233,8 @@ class EventPayloadBuilder
 
     /**
      * Build Hawk `arguments`: string list like "name = serializedValue" (from raw `args` via Serializer).
-     * Only the number of lines is limited ({@see StacktraceFrameBuilder::MAX_FRAME_ARGUMENTS}); lines are not truncated.
+     * Limits the number of lines ({@see StacktraceFrameBuilder::MAX_FRAME_ARGUMENTS}) and each line's byte length
+     * ({@see StacktraceFrameBuilder::MAX_ARGUMENT_LINE_BYTES}) for payload size.
      *
      * @param array $frame
      *
@@ -242,11 +243,12 @@ class EventPayloadBuilder
     private function buildArgumentsList(array $frame): array
     {
         $max = StacktraceFrameBuilder::MAX_FRAME_ARGUMENTS;
+        $maxBytes = StacktraceFrameBuilder::MAX_ARGUMENT_LINE_BYTES;
 
         if (isset($frame['arguments']) && is_array($frame['arguments'])) {
             $out = [];
             foreach (array_slice($frame['arguments'], 0, $max) as $line) {
-                $out[] = (string) $line;
+                $out[] = $this->truncateArgumentLineString((string) $line, $maxBytes);
             }
 
             return $out;
@@ -255,13 +257,22 @@ class EventPayloadBuilder
         if (!empty($frame['args']) && is_array($frame['args'])) {
             $out = [];
             foreach (array_slice($this->stacktraceFrameBuilder->getFormattedArguments($frame), 0, $max) as $line) {
-                $out[] = (string) $line;
+                $out[] = $this->truncateArgumentLineString((string) $line, $maxBytes);
             }
 
             return $out;
         }
 
         return [];
+    }
+
+    private function truncateArgumentLineString(string $line, int $maxBytes): string
+    {
+        if (strlen($line) <= $maxBytes) {
+            return $line;
+        }
+
+        return substr($line, 0, $maxBytes - 3) . '...';
     }
 
     /**

--- a/src/EventPayloadBuilder.php
+++ b/src/EventPayloadBuilder.php
@@ -41,7 +41,8 @@ class EventPayloadBuilder
     ];
 
     /**
-     * {@see transformForJson} max nesting — protects against $GLOBALS self-reference and similar cycles.
+     * {@see transformForJsonRecursive} max nesting — stops runaway recursion; combined with array reference
+     * stack for the same circular detection as {@see Serializer::prepare()}.
      */
     private const TRANSFORM_JSON_MAX_DEPTH = 32;
 
@@ -177,7 +178,7 @@ class EventPayloadBuilder
                         $value = is_object($value) ? get_class($value) : $value;
                     }
 
-                    $additional[$key] = $this->transformForJson($value, 0);
+                    $additional[$key] = $this->transformForJson($value);
                 }
             }
 
@@ -267,24 +268,43 @@ class EventPayloadBuilder
     }
 
     /**
-     * Transform values to JSON-serializable representation
+     * Transform frame extra fields for JSON — scalars, shallow objects, arrays with depth/cycle limits.
      *
      * @param mixed $value
-     * @param int   $depth
      *
      * @return mixed
      */
-    private function transformForJson($value, int $depth = 0)
+    private function transformForJson($value)
+    {
+        $stack = [];
+
+        return $this->transformForJsonRecursive($value, 0, $stack);
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return mixed
+     */
+    private function transformForJsonRecursive($value, int $depth, array &$stack)
     {
         if ($depth > self::TRANSFORM_JSON_MAX_DEPTH) {
             return '[max depth]';
         }
 
         if (is_array($value)) {
+            foreach ($stack as $ancestor) {
+                if ($value === $ancestor) {
+                    return '[circular]';
+                }
+            }
+
+            $stack[] = $value;
             $result = [];
             foreach ($value as $k => $v) {
-                $result[$k] = $this->transformForJson($v, $depth + 1);
+                $result[$k] = $this->transformForJsonRecursive($v, $depth + 1, $stack);
             }
+            array_pop($stack);
 
             return $result;
         }

--- a/src/EventPayloadBuilder.php
+++ b/src/EventPayloadBuilder.php
@@ -232,7 +232,8 @@ class EventPayloadBuilder
     }
 
     /**
-     * Build Hawk `arguments` (string[]) from a frame: prefers ready `arguments`, else formats raw `args`.
+     * Build Hawk `arguments`: string list like "name = serializedValue" (from raw `args` via Serializer).
+     * Only the number of lines is limited ({@see StacktraceFrameBuilder::MAX_FRAME_ARGUMENTS}); lines are not truncated.
      *
      * @param array $frame
      *
@@ -241,12 +242,11 @@ class EventPayloadBuilder
     private function buildArgumentsList(array $frame): array
     {
         $max = StacktraceFrameBuilder::MAX_FRAME_ARGUMENTS;
-        $maxBytes = StacktraceFrameBuilder::MAX_ARGUMENT_LINE_BYTES;
 
         if (isset($frame['arguments']) && is_array($frame['arguments'])) {
             $out = [];
             foreach (array_slice($frame['arguments'], 0, $max) as $line) {
-                $out[] = $this->truncateArgumentLineString((string) $line, $maxBytes);
+                $out[] = (string) $line;
             }
 
             return $out;
@@ -255,22 +255,13 @@ class EventPayloadBuilder
         if (!empty($frame['args']) && is_array($frame['args'])) {
             $out = [];
             foreach (array_slice($this->stacktraceFrameBuilder->getFormattedArguments($frame), 0, $max) as $line) {
-                $out[] = $this->truncateArgumentLineString((string) $line, $maxBytes);
+                $out[] = (string) $line;
             }
 
             return $out;
         }
 
         return [];
-    }
-
-    private function truncateArgumentLineString(string $line, int $maxBytes): string
-    {
-        if (strlen($line) <= $maxBytes) {
-            return $line;
-        }
-
-        return substr($line, 0, $maxBytes - 3) . '...';
     }
 
     /**

--- a/src/EventPayloadBuilder.php
+++ b/src/EventPayloadBuilder.php
@@ -41,6 +41,11 @@ class EventPayloadBuilder
     ];
 
     /**
+     * {@see transformForJson} max nesting — protects against $GLOBALS self-reference and similar cycles.
+     */
+    private const TRANSFORM_JSON_MAX_DEPTH = 32;
+
+    /**
      * EventPayloadFactory constructor.
      */
     public function __construct(StacktraceFrameBuilder $stacktraceFrameBuilder)
@@ -158,15 +163,21 @@ class EventPayloadBuilder
                 $functionName = (string) $frame['functionName'];
             }
 
+            $arguments = $this->buildArgumentsList($frame);
+
             $additional = [];
             foreach ($frame as $key => $value) {
                 if (!in_array($key, self::ALLOWED_KEYS, true)) {
+                    // Mapped to `arguments` via StacktraceFrameBuilder / string list; do not dump raw `args` here
+                    if ($key === 'args') {
+                        continue;
+                    }
                     // Drop heavy/unserializable objects from 'object' field; store class name instead
                     if ($key === 'object') {
                         $value = is_object($value) ? get_class($value) : $value;
                     }
 
-                    $additional[$key] = $this->transformForJson($value);
+                    $additional[$key] = $this->transformForJson($value, 0);
                 }
             }
 
@@ -176,9 +187,7 @@ class EventPayloadBuilder
                 'column'        => null,
                 'sourceCode'    => isset($frame['sourceCode']) && is_array($frame['sourceCode']) ? $frame['sourceCode'] : null,
                 'function'      => $functionName,
-                // Keep arguments only if it already looks like desired string[]; otherwise omit
-                // Limit argument processing to first 10 items to avoid performance issues
-                'arguments'     => (isset($frame['arguments']) && is_array($frame['arguments'])) ? array_values(array_map('strval', array_slice($frame['arguments'], 0, 10))) : [],
+                'arguments'     => $arguments,
                 'additionalData'=> $additional,
             ]);
         }
@@ -223,18 +232,65 @@ class EventPayloadBuilder
     }
 
     /**
+     * Build Hawk `arguments` (string[]) from a frame: prefers ready `arguments`, else formats raw `args`.
+     *
+     * @param array $frame
+     *
+     * @return array
+     */
+    private function buildArgumentsList(array $frame): array
+    {
+        $max = StacktraceFrameBuilder::MAX_FRAME_ARGUMENTS;
+        $maxBytes = StacktraceFrameBuilder::MAX_ARGUMENT_LINE_BYTES;
+
+        if (isset($frame['arguments']) && is_array($frame['arguments'])) {
+            $out = [];
+            foreach (array_slice($frame['arguments'], 0, $max) as $line) {
+                $out[] = $this->truncateArgumentLineString((string) $line, $maxBytes);
+            }
+
+            return $out;
+        }
+
+        if (!empty($frame['args']) && is_array($frame['args'])) {
+            $out = [];
+            foreach (array_slice($this->stacktraceFrameBuilder->getFormattedArguments($frame), 0, $max) as $line) {
+                $out[] = $this->truncateArgumentLineString((string) $line, $maxBytes);
+            }
+
+            return $out;
+        }
+
+        return [];
+    }
+
+    private function truncateArgumentLineString(string $line, int $maxBytes): string
+    {
+        if (strlen($line) <= $maxBytes) {
+            return $line;
+        }
+
+        return substr($line, 0, $maxBytes - 3) . '...';
+    }
+
+    /**
      * Transform values to JSON-serializable representation
      *
      * @param mixed $value
+     * @param int   $depth
      *
      * @return mixed
      */
-    private function transformForJson($value)
+    private function transformForJson($value, int $depth = 0)
     {
+        if ($depth > self::TRANSFORM_JSON_MAX_DEPTH) {
+            return '[max depth]';
+        }
+
         if (is_array($value)) {
             $result = [];
             foreach ($value as $k => $v) {
-                $result[$k] = $this->transformForJson($v);
+                $result[$k] = $this->transformForJson($v, $depth + 1);
             }
 
             return $result;

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -12,12 +12,6 @@ namespace Hawk;
 final class Serializer
 {
     /**
-     * Long scalar strings: insert U+200B every N chars so UIs can wrap (like soft word-break),
-     * without breaking JSON validity. Does not alter tokens like short keys.
-     */
-    private const SOFT_BREAK_EVERY_CHARS = 72;
-
-    /**
      * Process any value and makes it safe (in appropriate format) to send to hawk
      *
      * @param $value
@@ -88,34 +82,9 @@ final class Serializer
             return get_class($value);
         } elseif (is_resource($value)) {
             return 'Resource';
-        } elseif (is_string($value)) {
-            return $this->insertSoftBreaksInString($value);
         } else {
             return $value;
         }
-    }
-
-    /**
-     * Insert zero-width spaces for long strings so Hawk (or any monospace view) can wrap
-     * without CSS word-break; JSON remains valid after json_encode.
-     */
-    private function insertSoftBreaksInString(string $value): string
-    {
-        $len = strlen($value);
-        if ($len <= self::SOFT_BREAK_EVERY_CHARS) {
-            return $value;
-        }
-
-        $chunk = self::SOFT_BREAK_EVERY_CHARS;
-        $zwsp = "\u{200B}";
-
-        if (function_exists('mb_str_split')) {
-            $parts = mb_str_split($value, $chunk, 'UTF-8');
-
-            return implode($zwsp, $parts);
-        }
-
-        return implode($zwsp, str_split($value, $chunk));
     }
 
     /**

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -21,7 +21,8 @@ final class Serializer
     public function serializeValue($value): string
     {
         $flags = JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT;
-        $encoded = json_encode($this->prepare($value, 0), $flags);
+        $stack = [];
+        $encoded = json_encode($this->prepare($value, 0, $stack), $flags);
 
         if ($encoded === false) {
             return '';
@@ -40,23 +41,37 @@ final class Serializer
      *
      * @param mixed $value
      * @param int   $depth
+     * @param array $stack reference path (arrays only) to detect $GLOBALS-style cycles
      *
      * @return array|mixed|string
      */
-    private function prepare($value, int $depth = 0)
+    private function prepare($value, int $depth, array &$stack)
     {
         if ($depth > self::PREPARE_MAX_DEPTH) {
             return '[max depth]';
         }
 
         if (!is_object($value) && (is_array($value) || is_iterable($value))) {
+            if (is_array($value)) {
+                foreach ($stack as $ancestor) {
+                    if ($value === $ancestor) {
+                        return '[circular]';
+                    }
+                }
+                $stack[] = $value;
+            }
+
             $result = [];
             foreach ($value as $key => $subValue) {
                 if (is_array($subValue) || is_iterable($subValue)) {
-                    $result[$key] = $this->prepare($subValue, $depth + 1);
+                    $result[$key] = $this->prepare($subValue, $depth + 1, $stack);
                 } else {
                     $result[$key] = $this->transform($subValue);
                 }
+            }
+
+            if (is_array($value)) {
+                array_pop($stack);
             }
 
             return $result;

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -12,6 +12,12 @@ namespace Hawk;
 final class Serializer
 {
     /**
+     * Long scalar strings: insert U+200B every N chars so UIs can wrap (like soft word-break),
+     * without breaking JSON validity. Does not alter tokens like short keys.
+     */
+    private const SOFT_BREAK_EVERY_CHARS = 72;
+
+    /**
      * Process any value and makes it safe (in appropriate format) to send to hawk
      *
      * @param $value
@@ -20,7 +26,8 @@ final class Serializer
      */
     public function serializeValue($value): string
     {
-        $encoded = json_encode($this->prepare($value), JSON_UNESCAPED_UNICODE);
+        $flags = JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT;
+        $encoded = json_encode($this->prepare($value, 0), $flags);
 
         if ($encoded === false) {
             return '';
@@ -30,28 +37,38 @@ final class Serializer
     }
 
     /**
+     * Max nesting depth to avoid runaway recursion on $GLOBALS and similar circular structures.
+     */
+    private const PREPARE_MAX_DEPTH = 32;
+
+    /**
      * Prepares value for encoding
      *
-     * @param $value
+     * @param mixed $value
+     * @param int   $depth
      *
      * @return array|mixed|string
      */
-    private function prepare($value)
+    private function prepare($value, int $depth = 0)
     {
+        if ($depth > self::PREPARE_MAX_DEPTH) {
+            return '[max depth]';
+        }
+
         if (!is_object($value) && (is_array($value) || is_iterable($value))) {
             $result = [];
             foreach ($value as $key => $subValue) {
                 if (is_array($subValue) || is_iterable($subValue)) {
-                    $result[$key] = $this->prepare($subValue);
+                    $result[$key] = $this->prepare($subValue, $depth + 1);
                 } else {
                     $result[$key] = $this->transform($subValue);
                 }
             }
 
             return $result;
-        } else {
-            return $this->transform($value);
         }
+
+        return $this->transform($value);
     }
 
     /**
@@ -71,9 +88,34 @@ final class Serializer
             return get_class($value);
         } elseif (is_resource($value)) {
             return 'Resource';
+        } elseif (is_string($value)) {
+            return $this->insertSoftBreaksInString($value);
         } else {
             return $value;
         }
+    }
+
+    /**
+     * Insert zero-width spaces for long strings so Hawk (or any monospace view) can wrap
+     * without CSS word-break; JSON remains valid after json_encode.
+     */
+    private function insertSoftBreaksInString(string $value): string
+    {
+        $len = strlen($value);
+        if ($len <= self::SOFT_BREAK_EVERY_CHARS) {
+            return $value;
+        }
+
+        $chunk = self::SOFT_BREAK_EVERY_CHARS;
+        $zwsp = "\u{200B}";
+
+        if (function_exists('mb_str_split')) {
+            $parts = mb_str_split($value, $chunk, 'UTF-8');
+
+            return implode($zwsp, $parts);
+        }
+
+        return implode($zwsp, str_split($value, $chunk));
     }
 
     /**

--- a/src/StacktraceFrameBuilder.php
+++ b/src/StacktraceFrameBuilder.php
@@ -310,7 +310,30 @@ final class StacktraceFrameBuilder
     }
 
     /**
-     * Shorten text to byte length (`...` suffix when clipped); Unicode-safe via {@see mb_strcut} when mbstring exists.
+     * Longest prefix of $string whose byte length is at most $maxBytes and whose encoding is valid UTF-8.
+     * Used when {@see mb_strcut} is unavailable so {@see substr} never leaves a split codepoint (invalid JSON).
+     */
+    private static function utf8SafePrefixMaxBytes(string $string, int $maxBytes): string
+    {
+        if ($maxBytes <= 0) {
+            return '';
+        }
+
+        if (strlen($string) <= $maxBytes) {
+            return $string;
+        }
+
+        $s = substr($string, 0, $maxBytes);
+        while ($s !== '' && preg_match('//u', $s) !== 1) {
+            $s = substr($s, 0, -1);
+        }
+
+        return $s;
+    }
+
+    /**
+     * Shorten text to byte length (`...` suffix when clipped). Unicode-safe: {@see mb_strcut} when available,
+     * otherwise {@see utf8SafePrefixMaxBytes} (valid UTF-8 prefix, no split codepoints).
      */
     public static function truncateUtf8StringToMaxBytes(string $string, int $maxBytes): string
     {
@@ -327,7 +350,7 @@ final class StacktraceFrameBuilder
             return mb_strcut($string, 0, $cutLength, 'UTF-8') . '...';
         }
 
-        return substr($string, 0, $cutLength) . '...';
+        return self::utf8SafePrefixMaxBytes($string, $cutLength) . '...';
     }
 
     /**

--- a/src/StacktraceFrameBuilder.php
+++ b/src/StacktraceFrameBuilder.php
@@ -20,9 +20,10 @@ final class StacktraceFrameBuilder
     public const MAX_FRAME_ARGUMENTS = 20;
 
     /**
-     * Max length of one serialized "name = value" line (bytes; avoids huge JSON in events).
+     * Max UTF-8 byte length for the argument name (left-hand side only).
+     * Serialized values from {@see Serializer::serializeValue()} are not length-capped so JSON stays intact.
      */
-    public const MAX_ARGUMENT_LINE_BYTES = 2048;
+    public const MAX_ARGUMENT_NAME_BYTES = 256;
 
     /**
      * @var Serializer
@@ -276,8 +277,7 @@ final class StacktraceFrameBuilder
             $value = $this->serializer->serializeValue($value);
 
             try {
-                $line = sprintf('%s = %s', $name, $value);
-                $newArguments[] = $this->truncateArgumentLine($line);
+                $newArguments[] = self::formatTruncatedArgumentLine((string) $name, $value);
             } catch (\Exception $e) {
                 // Ignore unknown types
             }
@@ -286,13 +286,61 @@ final class StacktraceFrameBuilder
         return $newArguments;
     }
 
-    private function truncateArgumentLine(string $line): string
+    /**
+     * Build `"name = value"` — only the name may be shortened; serialized value is kept whole (valid JSON, etc.).
+     */
+    public static function formatTruncatedArgumentLine(string $name, string $serializedValue): string
     {
-        if (strlen($line) <= self::MAX_ARGUMENT_LINE_BYTES) {
+        $namePart = self::truncateUtf8StringToMaxBytes($name, self::MAX_ARGUMENT_NAME_BYTES);
+
+        return $namePart . ' = ' . $serializedValue;
+    }
+
+    /**
+     * Normalize one prebuilt `name = serializedValue` line: split at the first `" = "`, cap name only; value unchanged.
+     * Lines without `" = "` are returned as-is (no length limit).
+     */
+    public static function truncatePrebuiltArgumentLine(string $line): string
+    {
+        $separator = ' = ';
+        $position = strpos($line, $separator);
+        if ($position === false) {
             return $line;
         }
 
-        return substr($line, 0, self::MAX_ARGUMENT_LINE_BYTES - 3) . '...';
+        $nameRaw = substr($line, 0, $position);
+        $valueRaw = substr($line, $position + strlen($separator));
+
+        return self::formatTruncatedArgumentLine($nameRaw, $valueRaw);
+    }
+
+    /**
+     * Shorten text to byte length (`...` suffix when clipped); Unicode-safe via {@see mb_strcut} when mbstring exists.
+     */
+    public static function truncateUtf8StringToMaxBytes(string $string, int $maxBytes): string
+    {
+        if ($maxBytes <= 3) {
+            return substr('...', 0, $maxBytes);
+        }
+
+        if (strlen($string) <= $maxBytes) {
+            return $string;
+        }
+
+        $cutLength = $maxBytes - 3;
+        if (function_exists('mb_strcut')) {
+            return mb_strcut($string, 0, $cutLength, 'UTF-8') . '...';
+        }
+
+        return substr($string, 0, $cutLength) . '...';
+    }
+
+    /**
+     * @deprecated Use {@see truncateUtf8StringToMaxBytes} or {@see formatTruncatedArgumentLine}
+     */
+    public static function truncateArgumentLineBytes(string $line, int $maxBytes): string
+    {
+        return self::truncateUtf8StringToMaxBytes($line, $maxBytes);
     }
 
     /**

--- a/src/StacktraceFrameBuilder.php
+++ b/src/StacktraceFrameBuilder.php
@@ -20,6 +20,11 @@ final class StacktraceFrameBuilder
     public const MAX_FRAME_ARGUMENTS = 20;
 
     /**
+     * Max length of one serialized "name = value" line (bytes; avoids huge JSON in events).
+     */
+    public const MAX_ARGUMENT_LINE_BYTES = 2048;
+
+    /**
      * @var Serializer
      */
     private $serializer;
@@ -272,13 +277,22 @@ final class StacktraceFrameBuilder
 
             try {
                 $line = sprintf('%s = %s', $name, $value);
-                $newArguments[] = $line;
+                $newArguments[] = $this->truncateArgumentLine($line);
             } catch (\Exception $e) {
                 // Ignore unknown types
             }
         }
 
         return $newArguments;
+    }
+
+    private function truncateArgumentLine(string $line): string
+    {
+        if (strlen($line) <= self::MAX_ARGUMENT_LINE_BYTES) {
+            return $line;
+        }
+
+        return substr($line, 0, self::MAX_ARGUMENT_LINE_BYTES - 3) . '...';
     }
 
     /**

--- a/src/StacktraceFrameBuilder.php
+++ b/src/StacktraceFrameBuilder.php
@@ -274,13 +274,8 @@ final class StacktraceFrameBuilder
          */
         $newArguments = [];
         foreach ($arguments as $name => $value) {
-            $value = $this->serializer->serializeValue($value);
-
-            try {
-                $newArguments[] = self::formatTruncatedArgumentLine((string) $name, $value);
-            } catch (\Exception $e) {
-                // Ignore unknown types
-            }
+            $serialized = $this->serializer->serializeValue($value);
+            $newArguments[] = self::formatTruncatedArgumentLine((string) $name, $serialized);
         }
 
         return $newArguments;

--- a/src/StacktraceFrameBuilder.php
+++ b/src/StacktraceFrameBuilder.php
@@ -20,11 +20,6 @@ final class StacktraceFrameBuilder
     public const MAX_FRAME_ARGUMENTS = 5;
 
     /**
-     * Max length of one serialized "name = value" line (bytes; avoids huge JSON in events).
-     */
-    public const MAX_ARGUMENT_LINE_BYTES = 2048;
-
-    /**
      * @var Serializer
      */
     private $serializer;
@@ -277,22 +272,13 @@ final class StacktraceFrameBuilder
 
             try {
                 $line = sprintf('%s = %s', $name, $value);
-                $newArguments[] = $this->truncateArgumentLine($line);
+                $newArguments[] = $line;
             } catch (\Exception $e) {
                 // Ignore unknown types
             }
         }
 
         return $newArguments;
-    }
-
-    private function truncateArgumentLine(string $line): string
-    {
-        if (strlen($line) <= self::MAX_ARGUMENT_LINE_BYTES) {
-            return $line;
-        }
-
-        return substr($line, 0, self::MAX_ARGUMENT_LINE_BYTES - 3) . '...';
     }
 
     /**

--- a/src/StacktraceFrameBuilder.php
+++ b/src/StacktraceFrameBuilder.php
@@ -15,6 +15,16 @@ use Throwable;
 final class StacktraceFrameBuilder
 {
     /**
+     * Max function arguments to include per frame (payload size, CPU, Hawk limits).
+     */
+    public const MAX_FRAME_ARGUMENTS = 5;
+
+    /**
+     * Max length of one serialized "name = value" line (bytes; avoids huge JSON in events).
+     */
+    public const MAX_ARGUMENT_LINE_BYTES = 2048;
+
+    /**
      * @var Serializer
      */
     private $serializer;
@@ -184,6 +194,19 @@ final class StacktraceFrameBuilder
     }
 
     /**
+     * Format `args` from a raw debug_backtrace() frame to Hawk `arguments` (list of "name = value" strings).
+     * Public so {@see EventPayloadBuilder} can map `args` without duplicating logic.
+     *
+     * @param array $frame
+     *
+     * @return array
+     */
+    public function getFormattedArguments(array $frame): array
+    {
+        return $this->getArgs($frame);
+    }
+
+    /**
      * Get function arguments for a frame
      *
      * @param array $frame - backtrace frame
@@ -216,6 +239,9 @@ final class StacktraceFrameBuilder
          */
         if (!$reflection) {
             foreach ($frame['args'] as $index => $value) {
+                if ($index >= self::MAX_FRAME_ARGUMENTS) {
+                    break;
+                }
                 $arguments['arg' . $index] = $value;
             }
         } else {
@@ -230,6 +256,10 @@ final class StacktraceFrameBuilder
             foreach ($reflectionParams as $reflectionParam) {
                 $paramName = $reflectionParam->getName();
                 $paramPosition = $reflectionParam->getPosition();
+
+                if ($paramPosition >= self::MAX_FRAME_ARGUMENTS) {
+                    break;
+                }
 
                 if (isset($frame['args'][$paramPosition])) {
                     $arguments[$paramName] = $frame['args'][$paramPosition];
@@ -246,15 +276,23 @@ final class StacktraceFrameBuilder
             $value = $this->serializer->serializeValue($value);
 
             try {
-                $newArguments[] = sprintf('%s = %s', $name, $value);
+                $line = sprintf('%s = %s', $name, $value);
+                $newArguments[] = $this->truncateArgumentLine($line);
             } catch (\Exception $e) {
                 // Ignore unknown types
             }
         }
 
-        $arguments = $newArguments;
+        return $newArguments;
+    }
 
-        return $arguments;
+    private function truncateArgumentLine(string $line): string
+    {
+        if (strlen($line) <= self::MAX_ARGUMENT_LINE_BYTES) {
+            return $line;
+        }
+
+        return substr($line, 0, self::MAX_ARGUMENT_LINE_BYTES - 3) . '...';
     }
 
     /**

--- a/src/StacktraceFrameBuilder.php
+++ b/src/StacktraceFrameBuilder.php
@@ -17,7 +17,7 @@ final class StacktraceFrameBuilder
     /**
      * Max function arguments to include per frame (payload size, CPU, Hawk limits).
      */
-    public const MAX_FRAME_ARGUMENTS = 5;
+    public const MAX_FRAME_ARGUMENTS = 20;
 
     /**
      * Max length of one serialized "name = value" line (bytes; avoids huge JSON in events).

--- a/tests/Unit/EventPayloadBuilderTest.php
+++ b/tests/Unit/EventPayloadBuilderTest.php
@@ -49,23 +49,24 @@ class EventPayloadBuilderTest extends TestCase
     public function testNormalizeBacktraceLimitsArgumentCount(): void
     {
         [$builder, $normalize] = $this->builderWithNormalizeBacktrace();
+        $max = StacktraceFrameBuilder::MAX_FRAME_ARGUMENTS;
 
         $frame = [
             'file'     => '/x.php',
             'line'     => 1,
             'function' => 'not_registered_function_' . uniqid(),
-            'args'     => [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+            'args'     => array_values(range(1, $max + 5)),
         ];
 
         $stack = $normalize->invoke($builder, [$frame]);
 
-        $this->assertCount(StacktraceFrameBuilder::MAX_FRAME_ARGUMENTS, $stack[0]['arguments']);
+        $this->assertCount($max, $stack[0]['arguments']);
     }
 
-    public function testNormalizeBacktraceTruncatesPrebuiltArgumentLines(): void
+    public function testNormalizeBacktracePreservesPrebuiltArgumentLinesWithoutTrimming(): void
     {
         [$builder, $normalize] = $this->builderWithNormalizeBacktrace();
-        $long = str_repeat('Z', StacktraceFrameBuilder::MAX_ARGUMENT_LINE_BYTES + 100);
+        $long = str_repeat('Z', 5000);
 
         $frame = [
             'file'      => '/x.php',
@@ -77,8 +78,7 @@ class EventPayloadBuilderTest extends TestCase
         $stack = $normalize->invoke($builder, [$frame]);
         $line  = $stack[0]['arguments'][0] ?? '';
 
-        $this->assertLessThanOrEqual(StacktraceFrameBuilder::MAX_ARGUMENT_LINE_BYTES, strlen($line));
-        $this->assertStringEndsWith('...', $line);
+        $this->assertSame($long, $line);
     }
 
     public function testNormalizeBacktraceFinishesWithGlobalsLikeNestingInAdditionalData(): void

--- a/tests/Unit/EventPayloadBuilderTest.php
+++ b/tests/Unit/EventPayloadBuilderTest.php
@@ -53,7 +53,7 @@ class EventPayloadBuilderTest extends TestCase
         $frame = [
             'file'     => '/x.php',
             'line'     => 1,
-            'function' => 'not_registered_function_'.uniqid(),
+            'function' => 'not_registered_function_' . uniqid(),
             'args'     => [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         ];
 

--- a/tests/Unit/EventPayloadBuilderTest.php
+++ b/tests/Unit/EventPayloadBuilderTest.php
@@ -132,6 +132,28 @@ class EventPayloadBuilderTest extends TestCase
         $this->assertIsArray($stack[0]['additionalData']['custom'] ?? null);
     }
 
+    public function testNormalizeBacktraceMarksCircularArraysInAdditionalData(): void
+    {
+        [$builder, $normalize] = $this->builderWithNormalizeBacktrace();
+
+        $globalsLike = ['marker' => true];
+        $globalsLike['GLOBALS'] = &$globalsLike;
+
+        $frame = [
+            'file'     => '/x.php',
+            'line'     => 1,
+            'function' => 'x',
+            'args'     => [],
+            'custom'   => $globalsLike,
+        ];
+
+        $stack = $normalize->invoke($builder, [$frame]);
+        $custom = $stack[0]['additionalData']['custom'] ?? null;
+        $this->assertIsArray($custom);
+        $this->assertTrue($custom['marker']);
+        $this->assertSame('[circular]', $custom['GLOBALS']);
+    }
+
     public function testCreationWithDefaultException(): void
     {
         $context = [

--- a/tests/Unit/EventPayloadBuilderTest.php
+++ b/tests/Unit/EventPayloadBuilderTest.php
@@ -63,10 +63,10 @@ class EventPayloadBuilderTest extends TestCase
         $this->assertCount($max, $stack[0]['arguments']);
     }
 
-    public function testNormalizeBacktracePreservesPrebuiltArgumentLinesWithoutTrimming(): void
+    public function testNormalizeBacktraceTruncatesPrebuiltArgumentLines(): void
     {
         [$builder, $normalize] = $this->builderWithNormalizeBacktrace();
-        $long = str_repeat('Z', 5000);
+        $long = str_repeat('Z', StacktraceFrameBuilder::MAX_ARGUMENT_LINE_BYTES + 100);
 
         $frame = [
             'file'      => '/x.php',
@@ -78,7 +78,8 @@ class EventPayloadBuilderTest extends TestCase
         $stack = $normalize->invoke($builder, [$frame]);
         $line  = $stack[0]['arguments'][0] ?? '';
 
-        $this->assertSame($long, $line);
+        $this->assertLessThanOrEqual(StacktraceFrameBuilder::MAX_ARGUMENT_LINE_BYTES, strlen($line));
+        $this->assertStringEndsWith('...', $line);
     }
 
     public function testNormalizeBacktraceFinishesWithGlobalsLikeNestingInAdditionalData(): void

--- a/tests/Unit/EventPayloadBuilderTest.php
+++ b/tests/Unit/EventPayloadBuilderTest.php
@@ -13,6 +13,100 @@ use PHPUnit\Framework\TestCase;
 
 class EventPayloadBuilderTest extends TestCase
 {
+    /**
+     * @return array{0: EventPayloadBuilder, 1: \ReflectionMethod}
+     */
+    private function builderWithNormalizeBacktrace(): array
+    {
+        $serializer = new Serializer();
+        $stack = new StacktraceFrameBuilder($serializer);
+        $builder = new EventPayloadBuilder($stack);
+        $m = new \ReflectionMethod(EventPayloadBuilder::class, 'normalizeBacktrace');
+        $m->setAccessible(true);
+
+        return [$builder, $m];
+    }
+
+    public function testNormalizeBacktraceDoesNotPutRawArgsIntoAdditionalData(): void
+    {
+        [$builder, $normalize] = $this->builderWithNormalizeBacktrace();
+
+        $frame = [
+            'file'     => '/fake/handler.php',
+            'line'     => 7,
+            'class'    => 'SomeErrorHandler',
+            'type'     => '::',
+            'function' => 'handle',
+            'args'     => [256, 'message', __FILE__, 7, ['nested' => true]],
+        ];
+
+        $stack = $normalize->invoke($builder, [$frame]);
+
+        $this->assertArrayNotHasKey('args', $stack[0]['additionalData'] ?? []);
+        $this->assertNotEmpty($stack[0]['arguments'] ?? []);
+    }
+
+    public function testNormalizeBacktraceLimitsArgumentCount(): void
+    {
+        [$builder, $normalize] = $this->builderWithNormalizeBacktrace();
+
+        $frame = [
+            'file'     => '/x.php',
+            'line'     => 1,
+            'function' => 'not_registered_function_'.uniqid(),
+            'args'     => [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        ];
+
+        $stack = $normalize->invoke($builder, [$frame]);
+
+        $this->assertCount(StacktraceFrameBuilder::MAX_FRAME_ARGUMENTS, $stack[0]['arguments']);
+    }
+
+    public function testNormalizeBacktraceTruncatesPrebuiltArgumentLines(): void
+    {
+        [$builder, $normalize] = $this->builderWithNormalizeBacktrace();
+        $long = str_repeat('Z', StacktraceFrameBuilder::MAX_ARGUMENT_LINE_BYTES + 100);
+
+        $frame = [
+            'file'      => '/x.php',
+            'line'      => 1,
+            'function'  => 'f',
+            'arguments' => [$long],
+        ];
+
+        $stack = $normalize->invoke($builder, [$frame]);
+        $line  = $stack[0]['arguments'][0] ?? '';
+
+        $this->assertLessThanOrEqual(StacktraceFrameBuilder::MAX_ARGUMENT_LINE_BYTES, strlen($line));
+        $this->assertStringEndsWith('...', $line);
+    }
+
+    public function testNormalizeBacktraceFinishesWithGlobalsLikeNestingInAdditionalData(): void
+    {
+        [$builder, $normalize] = $this->builderWithNormalizeBacktrace();
+
+        $deep = ['level' => []];
+        $cur =& $deep['level'];
+        for ($i = 0; $i < 50; $i++) {
+            $cur['d'] = [];
+            $cur =& $cur['d'];
+        }
+        $cur['leaf'] = 1;
+
+        $frame = [
+            'file'     => '/x.php',
+            'line'     => 1,
+            'function' => 'x',
+            'class'    => 'C',
+            'type'     => '->',
+            'args'     => [1],
+            'custom'   => $deep,
+        ];
+
+        $stack = $normalize->invoke($builder, [$frame]);
+        $this->assertIsArray($stack[0]['additionalData']['custom'] ?? null);
+    }
+
     public function testCreationWithDefaultException(): void
     {
         $context = [

--- a/tests/Unit/EventPayloadBuilderTest.php
+++ b/tests/Unit/EventPayloadBuilderTest.php
@@ -63,10 +63,10 @@ class EventPayloadBuilderTest extends TestCase
         $this->assertCount($max, $stack[0]['arguments']);
     }
 
-    public function testNormalizeBacktraceTruncatesPrebuiltArgumentLines(): void
+    public function testNormalizeBacktracePreservesPrebuiltArgumentLineWithoutDelimiter(): void
     {
         [$builder, $normalize] = $this->builderWithNormalizeBacktrace();
-        $long = str_repeat('Z', StacktraceFrameBuilder::MAX_ARGUMENT_LINE_BYTES + 100);
+        $long = str_repeat('Z', 50_000);
 
         $frame = [
             'file'      => '/x.php',
@@ -78,8 +78,32 @@ class EventPayloadBuilderTest extends TestCase
         $stack = $normalize->invoke($builder, [$frame]);
         $line  = $stack[0]['arguments'][0] ?? '';
 
-        $this->assertLessThanOrEqual(StacktraceFrameBuilder::MAX_ARGUMENT_LINE_BYTES, strlen($line));
-        $this->assertStringEndsWith('...', $line);
+        $this->assertSame($long, $line);
+    }
+
+    public function testNormalizeBacktraceTruncatesPrebuiltNameOnlyValuePreserved(): void
+    {
+        [$builder, $normalize] = $this->builderWithNormalizeBacktrace();
+        $longName = str_repeat('K', StacktraceFrameBuilder::MAX_ARGUMENT_NAME_BYTES + 50);
+        $longValue = str_repeat('V', 12_345);
+        $prebuiltLine = $longName . ' = ' . $longValue;
+
+        $frame = [
+            'file'      => '/x.php',
+            'line'      => 1,
+            'function'  => 'f',
+            'arguments' => [$prebuiltLine],
+        ];
+
+        $stack = $normalize->invoke($builder, [$frame]);
+        $line  = $stack[0]['arguments'][0] ?? '';
+        $parts = explode(' = ', $line, 2);
+        $this->assertCount(2, $parts);
+        [$namePart, $valuePart] = $parts;
+
+        $this->assertLessThanOrEqual(StacktraceFrameBuilder::MAX_ARGUMENT_NAME_BYTES, strlen($namePart));
+        $this->assertStringEndsWith('...', $namePart);
+        $this->assertSame($longValue, $valuePart);
     }
 
     public function testNormalizeBacktraceFinishesWithGlobalsLikeNestingInAdditionalData(): void

--- a/tests/Unit/SerializerTest.php
+++ b/tests/Unit/SerializerTest.php
@@ -74,7 +74,7 @@ class SerializerTest extends TestCase
 
     public function testSerializationPreservesLongScalarStringsForRoundTripJson(): void
     {
-        $long = \str_repeat("word spaced text ", 280);
+        $long = \str_repeat('word spaced text ', 280);
         $fixture = new Serializer();
         $decoded = json_decode($fixture->serializeValue(['blob' => $long]), true, 512, JSON_THROW_ON_ERROR);
 

--- a/tests/Unit/SerializerTest.php
+++ b/tests/Unit/SerializerTest.php
@@ -19,7 +19,17 @@ class SerializerTest extends TestCase
         $fixture = new Serializer();
         $result = $fixture->serializeValue($testCase['value']);
 
-        $this->assertEquals($testCase['expect'], $result);
+        if ($testCase['expect'] === '') {
+            $this->assertSame('', $result);
+
+            return;
+        }
+
+        // Output uses JSON_PRETTY_PRINT; compare decoded structure (and scalars) for stability
+        $this->assertEquals(
+            json_decode($testCase['expect'], true, 512, JSON_THROW_ON_ERROR),
+            json_decode($result, true, 512, JSON_THROW_ON_ERROR)
+        );
     }
 
     public function testSerializationWithMediumSizeArray(): void
@@ -30,21 +40,34 @@ class SerializerTest extends TestCase
         $fixture = new Serializer();
         $result = $fixture->serializeValue($mediumArray);
 
-        $this->assertEquals('{"1":{"2":{"3":{"4":{"5":{"6":{"7":{"8":{"9":{"10":{"11":{"12":{"13":{"14":{"15":{"16":{"17":{"18":{"19":[]}}}}}}}}}}}}}}}}}}}', $result);
+        $this->assertEquals(
+            json_decode('{"1":{"2":{"3":{"4":{"5":{"6":{"7":{"8":{"9":{"10":{"11":{"12":{"13":{"14":{"15":{"16":{"17":{"18":{"19":[]}}}}}}}}}}}}}}}}}}}', true, 512, JSON_THROW_ON_ERROR),
+            json_decode($result, true, 512, JSON_THROW_ON_ERROR)
+        );
     }
 
     public function testSerializationWithLargeArray(): void
     {
-        // MaxDepth is 1000
         $largeArray = [];
         $this->fillArray($largeArray);
 
         $fixture = new Serializer();
-
-        // json_encode will return false and result is empty string
         $result = $fixture->serializeValue($largeArray);
 
-        $this->assertEquals('', trim($result));
+        // Very deep trees are truncated instead of making json_encode fail
+        $this->assertStringContainsString('[max depth]', $result);
+        $this->assertIsArray(json_decode($result, true));
+    }
+
+    public function testLongStringValuesGetSoftBreakPointsForDisplay(): void
+    {
+        $long = str_repeat('a', 200);
+        $fixture = new Serializer();
+        $result = $fixture->serializeValue($long);
+        $this->assertStringContainsString("\u{200B}", $result);
+        $decoded = json_decode($result, false, 512, JSON_THROW_ON_ERROR);
+        $this->assertIsString($decoded);
+        $this->assertSame($long, str_replace("\u{200B}", '', $decoded));
     }
 
     /**

--- a/tests/Unit/SerializerTest.php
+++ b/tests/Unit/SerializerTest.php
@@ -59,17 +59,6 @@ class SerializerTest extends TestCase
         $this->assertIsArray(json_decode($result, true));
     }
 
-    public function testLongStringValuesGetSoftBreakPointsForDisplay(): void
-    {
-        $long = str_repeat('a', 200);
-        $fixture = new Serializer();
-        $result = $fixture->serializeValue($long);
-        $this->assertStringContainsString("\u{200B}", $result);
-        $decoded = json_decode($result, false, 512, JSON_THROW_ON_ERROR);
-        $this->assertIsString($decoded);
-        $this->assertSame($long, str_replace("\u{200B}", '', $decoded));
-    }
-
     /**
      * Fills empty array with values:
      *   [1 => [2 => [3 => ....]]]

--- a/tests/Unit/SerializerTest.php
+++ b/tests/Unit/SerializerTest.php
@@ -59,6 +59,28 @@ class SerializerTest extends TestCase
         $this->assertIsArray(json_decode($result, true));
     }
 
+    public function testSerializationReplacesCircularArrayReferences(): void
+    {
+        $globalsLike = [];
+        $globalsLike['GLOBALS'] = &$globalsLike;
+        $globalsLike['_marker'] = 'e2e';
+
+        $fixture = new Serializer();
+        $decoded = json_decode($fixture->serializeValue($globalsLike), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('[circular]', $decoded['GLOBALS']);
+        $this->assertSame('e2e', $decoded['_marker']);
+    }
+
+    public function testSerializationPreservesLongScalarStringsForRoundTripJson(): void
+    {
+        $long = \str_repeat("word spaced text ", 280);
+        $fixture = new Serializer();
+        $decoded = json_decode($fixture->serializeValue(['blob' => $long]), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame($long, $decoded['blob']);
+    }
+
     /**
      * Fills empty array with values:
      *   [1 => [2 => [3 => ....]]]

--- a/tests/Unit/StacktraceFrameBuilderTest.php
+++ b/tests/Unit/StacktraceFrameBuilderTest.php
@@ -10,6 +10,26 @@ use PHPUnit\Framework\TestCase;
 
 class StacktraceFrameBuilderTest extends TestCase
 {
+    public function testTruncateUtf8StringToMaxBytesPreservesValidUtf8WhenCuttingMultibyte(): void
+    {
+        $ru = str_repeat('П', 200);
+        $out = StacktraceFrameBuilder::truncateUtf8StringToMaxBytes($ru, 80);
+        $this->assertLessThanOrEqual(80, strlen($out));
+        $this->assertStringEndsWith('...', $out);
+        $this->assertSame(1, preg_match('//u', $out), 'output must be valid UTF-8 for JSON');
+        $this->assertNotFalse(json_encode($out, JSON_UNESCAPED_UNICODE));
+    }
+
+    public function testUtf8SafePrefixMaxBytesViaReflectionDoesNotSplitTwoByteChar(): void
+    {
+        $method = new \ReflectionMethod(StacktraceFrameBuilder::class, 'utf8SafePrefixMaxBytes');
+        $method->setAccessible(true);
+        // 'П' is U+041F, two bytes in UTF-8
+        $this->assertSame('', $method->invoke(null, 'Президент', 1));
+        $this->assertSame('П', $method->invoke(null, 'Президент', 2));
+        $this->assertSame('Пр', $method->invoke(null, 'Президент', 4));
+    }
+
     public function testResultingStacktraceFrames(): void
     {
         $serializer = new Serializer();


### PR DESCRIPTION
### Summary

Hardens Hawk event and stacktrace payloads when frames carry deeply nested, self-referential, or bulky data (e.g. $GLOBALS-shaped arrays in arguments or extra frame fields). Stack arguments stay a list of strings name = serializedValue: serialized values are full JSON from Serializer (pretty-printed, circular keys become [circular]) so they stay json_decode-friendly in the Hawk UI; only parameter names are shortened. Argument count per frame is capped; there is no byte cap on the value side by design (trade-off vs. transport/API limits elsewhere).

### What changed

- Serializer::prepare — max nesting depth; circular array detection ([circular]); output via JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT.
- EventPayloadBuilder::normalizeBacktrace — allowlisted frame keys; maps raw args → Hawk arguments without copying args into additionalData; transformForJson for extra keys uses depth limit + reference stack (same circular idea as Serializer); arguments list length capped.
- StacktraceFrameBuilder — caps arguments per frame; formats lines with name-only truncation; no length truncation of the serialized value / lines without = pass through unchanged; removed redundant try/catch around formatting.
- Tests — normalization, argument count limit, long prebuilt lines (full value preserved), deep additionalData, circular additionalData, serializer depth / circular / long-string behavior.